### PR TITLE
Release infernal 1.1.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ The latest release of Infernal is
     thanks to
     <a href="https://github.com/bgruening">Bj&ouml;rn Gr&uuml;ning</a>.
     If you have <code>conda</code>, you can install with: <br/>
-    <code>conda install -c bioconda infernal=1.1.2</code>
+    <code>conda install -c bioconda infernal</code>
 
   <li> <a href="https://github.com/Homebrew/homebrew-science">Homebrew Science package</a>.
        With <code>homebrew</code>, you can install with <br />

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@ The latest release of Infernal is
        <a href="http://eddylab.org/infernal/infernal-1.1.5-linux-intel-gcc.tar.gz"> 
        [infernal 1.1.5 with Linux/Intel binaries, 48.4 MB] </a> <br />
        <a href="http://eddylab.org/infernal/infernal-1.1.5-macosx-silicon.tar.gz">
-       [infernal 1.1.5 with MacOSX/Silicon binaries, 45.5 MB] </a>
+       [infernal 1.1.5 with MacOSX/Silicon binaries, 45.5 MB] </a> <br />
        <a href="http://eddylab.org/infernal/infernal-1.1.5-macosx-intel.tar.gz">
        [infernal 1.1.5 with MacOSX/Intel binaries, 46.7 MB] </a>
 </ul>


### PR DESCRIPTION
Adds a line break I missed, and removes version from conda install, which I think is right, but please take a look. I'm not familiar with conda but from this page: https://anaconda.org/bioconda/infernal it seems like you don't need to specify the version (and probably shouldn't unless you want an old one).